### PR TITLE
Fix ShaCalculator handling of mixed-case keys.

### DIFF
--- a/lib/epdq/sha_calculator.rb
+++ b/lib/epdq/sha_calculator.rb
@@ -5,7 +5,10 @@ module EPDQ
   class ShaCalculator
 
     def initialize(parameters = {}, sha, sha_type)
-      @parameters = parameters
+      @parameters = {}
+      parameters.each do |k,v|
+        @parameters[k.to_s.upcase] = v if v && v.to_s.length > 0
+      end
       @sha = sha
       @sha_type = sha_type
     end
@@ -16,10 +19,7 @@ module EPDQ
       buffer = ""
 
       @parameters.keys.sort.each do |key|
-        value = @parameters[key]
-        if value && value.to_s.length > 0
-          buffer << "#{key.upcase}=#{value}#{@sha}"
-        end
+        buffer << "#{key}=#{@parameters[key]}#{@sha}"
       end
 
       case @sha_type.to_sym

--- a/test/response_test.rb
+++ b/test/response_test.rb
@@ -14,6 +14,13 @@ class ResponseTest < Test::Unit::TestCase
     assert response.valid_shasign?
   end
 
+  test "valid_sha? with mixed case keys" do
+    query_string = "ACCEPTANCE=1234&AMOUNT=15.00&brand=VISA&CARDNO=xxxxxxxxxxxx1111&CURRENCY=EUR&ncerror=0&ORDERID=12&PAYID=32100123&PM=CreditCard&STATUS=9&SHASIGN=8DC2A769700CA4B3DF87FE8E3B6FD162D6F6A5FA"
+
+    response = EPDQ::Response.new(query_string)
+    assert response.valid_shasign?
+  end
+
   test "parameters" do
     query_string = "ACCEPTANCE=1234&AMOUNT=15.00&BRAND=VISA&CARDNO=xxxxxxxxxxxx1111&CURRENCY=EUR&NCERROR=0&ORDERID=12&PAYID=32100123&PM=CreditCard&STATUS=9&SHASIGN=8DC2A769700CA4B3DF87FE8E3B6FD162D6F6A5FA"
 


### PR DESCRIPTION
This was sorting the keys before upcasing them, which would result in them being used in the wrong order.
